### PR TITLE
[STEP1] James

### DIFF
--- a/StreamChat/.swiftlint.yml
+++ b/StreamChat/.swiftlint.yml
@@ -1,0 +1,7 @@
+disabled_rules:
+- line_length
+- trailing_whitespace
+
+included:
+excluded:
+- StreamChatTests/

--- a/StreamChat/.swiftlint.yml
+++ b/StreamChat/.swiftlint.yml
@@ -5,3 +5,4 @@ disabled_rules:
 included:
 excluded:
 - StreamChatTests/
+- AppDelegate/

--- a/StreamChat/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat/StreamChat.xcodeproj/project.pbxproj
@@ -17,7 +17,21 @@
 		EAEB958726C56307001A500D /* StreamInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEB958626C56307001A500D /* StreamInformation.swift */; };
 		EAEB958926C580F0001A500D /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEB958826C580F0001A500D /* Message.swift */; };
 		EAEB958B26C58138001A500D /* MessageSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEB958A26C58138001A500D /* MessageSender.swift */; };
+		EAEB958D26C64060001A500D /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = EAEB958C26C64060001A500D /* .swiftlint.yml */; };
+		EAEB95C226C64A1F001A500D /* StreamChatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEB95C126C64A1F001A500D /* StreamChatTests.swift */; };
+		EAEB95CA26C65BAF001A500D /* ConnectionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEB95C926C65BAF001A500D /* ConnectionConfiguration.swift */; };
+		EAEB95CC26C65C95001A500D /* StreamError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEB95CB26C65C95001A500D /* StreamError.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		EAEB95C426C64A1F001A500D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C7927549262C562B00EF5D3A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C7927550262C562B00EF5D3A;
+			remoteInfo = StreamChat;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		C7927551262C562B00EF5D3A /* StreamChat.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StreamChat.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -32,10 +46,23 @@
 		EAEB958626C56307001A500D /* StreamInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamInformation.swift; sourceTree = "<group>"; };
 		EAEB958826C580F0001A500D /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		EAEB958A26C58138001A500D /* MessageSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageSender.swift; sourceTree = "<group>"; };
+		EAEB958C26C64060001A500D /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		EAEB95BF26C64A1F001A500D /* StreamChatTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StreamChatTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		EAEB95C126C64A1F001A500D /* StreamChatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamChatTests.swift; sourceTree = "<group>"; };
+		EAEB95C326C64A1F001A500D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		EAEB95C926C65BAF001A500D /* ConnectionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionConfiguration.swift; sourceTree = "<group>"; };
+		EAEB95CB26C65C95001A500D /* StreamError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		C792754E262C562B00EF5D3A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EAEB95BC26C64A1F001A500D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -48,7 +75,9 @@
 		C7927548262C562B00EF5D3A = {
 			isa = PBXGroup;
 			children = (
+				EAEB958C26C64060001A500D /* .swiftlint.yml */,
 				C7927553262C562B00EF5D3A /* StreamChat */,
+				EAEB95C026C64A1F001A500D /* StreamChatTests */,
 				C7927552262C562B00EF5D3A /* Products */,
 			);
 			sourceTree = "<group>";
@@ -57,6 +86,7 @@
 			isa = PBXGroup;
 			children = (
 				C7927551262C562B00EF5D3A /* StreamChat.app */,
+				EAEB95BF26C64A1F001A500D /* StreamChatTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -80,6 +110,7 @@
 		EAEB958126C55C31001A500D /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				EAEB958E26C6435F001A500D /* Protocols */,
 				C7927558262C562B00EF5D3A /* ViewController.swift */,
 			);
 			path = Controllers;
@@ -99,8 +130,26 @@
 				EAEB958626C56307001A500D /* StreamInformation.swift */,
 				EAEB958826C580F0001A500D /* Message.swift */,
 				EAEB958A26C58138001A500D /* MessageSender.swift */,
+				EAEB95C926C65BAF001A500D /* ConnectionConfiguration.swift */,
+				EAEB95CB26C65C95001A500D /* StreamError.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		EAEB958E26C6435F001A500D /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Protocols;
+			sourceTree = "<group>";
+		};
+		EAEB95C026C64A1F001A500D /* StreamChatTests */ = {
+			isa = PBXGroup;
+			children = (
+				EAEB95C126C64A1F001A500D /* StreamChatTests.swift */,
+				EAEB95C326C64A1F001A500D /* Info.plist */,
+			);
+			path = StreamChatTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -124,17 +173,39 @@
 			productReference = C7927551262C562B00EF5D3A /* StreamChat.app */;
 			productType = "com.apple.product-type.application";
 		};
+		EAEB95BE26C64A1F001A500D /* StreamChatTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EAEB95C626C64A1F001A500D /* Build configuration list for PBXNativeTarget "StreamChatTests" */;
+			buildPhases = (
+				EAEB95BB26C64A1F001A500D /* Sources */,
+				EAEB95BC26C64A1F001A500D /* Frameworks */,
+				EAEB95BD26C64A1F001A500D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				EAEB95C526C64A1F001A500D /* PBXTargetDependency */,
+			);
+			name = StreamChatTests;
+			productName = StreamChatTests;
+			productReference = EAEB95BF26C64A1F001A500D /* StreamChatTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		C7927549262C562B00EF5D3A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1240;
+				LastSwiftUpdateCheck = 1250;
 				LastUpgradeCheck = 1240;
 				TargetAttributes = {
 					C7927550262C562B00EF5D3A = {
 						CreatedOnToolsVersion = 12.4;
+					};
+					EAEB95BE26C64A1F001A500D = {
+						CreatedOnToolsVersion = 12.5.1;
+						TestTargetID = C7927550262C562B00EF5D3A;
 					};
 				};
 			};
@@ -152,6 +223,7 @@
 			projectRoot = "";
 			targets = (
 				C7927550262C562B00EF5D3A /* StreamChat */,
+				EAEB95BE26C64A1F001A500D /* StreamChatTests */,
 			);
 		};
 /* End PBXProject section */
@@ -161,9 +233,17 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EAEB958D26C64060001A500D /* .swiftlint.yml in Resources */,
 				C7927561262C562E00EF5D3A /* LaunchScreen.storyboard in Resources */,
 				C792755E262C562E00EF5D3A /* Assets.xcassets in Resources */,
 				C792755C262C562B00EF5D3A /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EAEB95BD26C64A1F001A500D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -194,17 +274,35 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EAEB95CA26C65BAF001A500D /* ConnectionConfiguration.swift in Sources */,
 				C7927559262C562B00EF5D3A /* ViewController.swift in Sources */,
 				EAEB958726C56307001A500D /* StreamInformation.swift in Sources */,
 				C7927555262C562B00EF5D3A /* AppDelegate.swift in Sources */,
 				EAEB958B26C58138001A500D /* MessageSender.swift in Sources */,
 				EAEB958926C580F0001A500D /* Message.swift in Sources */,
 				EAEB958026C559C4001A500D /* ChatRoom.swift in Sources */,
+				EAEB95CC26C65C95001A500D /* StreamError.swift in Sources */,
 				C7927557262C562B00EF5D3A /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EAEB95BB26C64A1F001A500D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EAEB95C226C64A1F001A500D /* StreamChatTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		EAEB95C526C64A1F001A500D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C7927550262C562B00EF5D3A /* StreamChat */;
+			targetProxy = EAEB95C426C64A1F001A500D /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		C792755A262C562B00EF5D3A /* Main.storyboard */ = {
@@ -378,6 +476,48 @@
 			};
 			name = Release;
 		};
+		EAEB95C726C64A1F001A500D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = Z34KHT5SJG;
+				INFOPLIST_FILE = StreamChatTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.inwoodev.StreamChatTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StreamChat.app/StreamChat";
+			};
+			name = Debug;
+		};
+		EAEB95C826C64A1F001A500D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = Z34KHT5SJG;
+				INFOPLIST_FILE = StreamChatTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.inwoodev.StreamChatTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StreamChat.app/StreamChat";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -395,6 +535,15 @@
 			buildConfigurations = (
 				C7927566262C562E00EF5D3A /* Debug */,
 				C7927567262C562E00EF5D3A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EAEB95C626C64A1F001A500D /* Build configuration list for PBXNativeTarget "StreamChatTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EAEB95C726C64A1F001A500D /* Debug */,
+				EAEB95C826C64A1F001A500D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/StreamChat/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat/StreamChat.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		C792755C262C562B00EF5D3A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C792755A262C562B00EF5D3A /* Main.storyboard */; };
 		C792755E262C562E00EF5D3A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C792755D262C562E00EF5D3A /* Assets.xcassets */; };
 		C7927561262C562E00EF5D3A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C792755F262C562E00EF5D3A /* LaunchScreen.storyboard */; };
+		EAA925C926CB5142003D1D8F /* ChatNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAA925C826CB5142003D1D8F /* ChatNetworkManager.swift */; };
+		EAA925CB26CB548D003D1D8F /* ChatNetworkManageable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAA925CA26CB548D003D1D8F /* ChatNetworkManageable.swift */; };
 		EAEB958026C559C4001A500D /* ChatRoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEB957F26C559C4001A500D /* ChatRoom.swift */; };
 		EAEB958726C56307001A500D /* StreamInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEB958626C56307001A500D /* StreamInformation.swift */; };
 		EAEB958926C580F0001A500D /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEB958826C580F0001A500D /* Message.swift */; };
@@ -46,6 +48,8 @@
 		C792755D262C562E00EF5D3A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C7927560262C562E00EF5D3A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C7927562262C562E00EF5D3A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		EAA925C826CB5142003D1D8F /* ChatNetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatNetworkManager.swift; sourceTree = "<group>"; };
+		EAA925CA26CB548D003D1D8F /* ChatNetworkManageable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatNetworkManageable.swift; sourceTree = "<group>"; };
 		EAEB957F26C559C4001A500D /* ChatRoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoom.swift; sourceTree = "<group>"; };
 		EAEB958626C56307001A500D /* StreamInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamInformation.swift; sourceTree = "<group>"; };
 		EAEB958826C580F0001A500D /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
@@ -141,6 +145,7 @@
 				EAEB958A26C58138001A500D /* MessageSender.swift */,
 				EAEB95C926C65BAF001A500D /* ConnectionConfiguration.swift */,
 				EAEB95CB26C65C95001A500D /* StreamError.swift */,
+				EAA925C826CB5142003D1D8F /* ChatNetworkManager.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -168,6 +173,7 @@
 			isa = PBXGroup;
 			children = (
 				EAEB95D026C66DC7001A500D /* URLSessionProtocol.swift */,
+				EAA925CA26CB548D003D1D8F /* ChatNetworkManageable.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -295,8 +301,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				EAEB95D126C66DC7001A500D /* URLSessionProtocol.swift in Sources */,
+				EAA925CB26CB548D003D1D8F /* ChatNetworkManageable.swift in Sources */,
 				EAEB95CA26C65BAF001A500D /* ConnectionConfiguration.swift in Sources */,
 				C7927559262C562B00EF5D3A /* ViewController.swift in Sources */,
+				EAA925C926CB5142003D1D8F /* ChatNetworkManager.swift in Sources */,
 				EAEB958726C56307001A500D /* StreamInformation.swift in Sources */,
 				C7927555262C562B00EF5D3A /* AppDelegate.swift in Sources */,
 				EAEB958B26C58138001A500D /* MessageSender.swift in Sources */,

--- a/StreamChat/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat/StreamChat.xcodeproj/project.pbxproj
@@ -21,6 +21,10 @@
 		EAEB95C226C64A1F001A500D /* StreamChatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEB95C126C64A1F001A500D /* StreamChatTests.swift */; };
 		EAEB95CA26C65BAF001A500D /* ConnectionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEB95C926C65BAF001A500D /* ConnectionConfiguration.swift */; };
 		EAEB95CC26C65C95001A500D /* StreamError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEB95CB26C65C95001A500D /* StreamError.swift */; };
+		EAEB95D126C66DC7001A500D /* URLSessionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEB95D026C66DC7001A500D /* URLSessionProtocol.swift */; };
+		EAEB95D326C66F57001A500D /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEB95D226C66F57001A500D /* MockURLSession.swift */; };
+		EAEB95D526C67010001A500D /* MockStreamTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEB95D426C67010001A500D /* MockStreamTask.swift */; };
+		EAEB95D726C68379001A500D /* DummyData.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEB95D626C68379001A500D /* DummyData.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -52,6 +56,10 @@
 		EAEB95C326C64A1F001A500D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EAEB95C926C65BAF001A500D /* ConnectionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionConfiguration.swift; sourceTree = "<group>"; };
 		EAEB95CB26C65C95001A500D /* StreamError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamError.swift; sourceTree = "<group>"; };
+		EAEB95D026C66DC7001A500D /* URLSessionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionProtocol.swift; sourceTree = "<group>"; };
+		EAEB95D226C66F57001A500D /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
+		EAEB95D426C67010001A500D /* MockStreamTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStreamTask.swift; sourceTree = "<group>"; };
+		EAEB95D626C68379001A500D /* DummyData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyData.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -126,6 +134,7 @@
 		EAEB958326C55C4B001A500D /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				EAEB95CD26C66C83001A500D /* Protocols */,
 				EAEB957F26C559C4001A500D /* ChatRoom.swift */,
 				EAEB958626C56307001A500D /* StreamInformation.swift */,
 				EAEB958826C580F0001A500D /* Message.swift */,
@@ -148,8 +157,19 @@
 			children = (
 				EAEB95C126C64A1F001A500D /* StreamChatTests.swift */,
 				EAEB95C326C64A1F001A500D /* Info.plist */,
+				EAEB95D226C66F57001A500D /* MockURLSession.swift */,
+				EAEB95D426C67010001A500D /* MockStreamTask.swift */,
+				EAEB95D626C68379001A500D /* DummyData.swift */,
 			);
 			path = StreamChatTests;
+			sourceTree = "<group>";
+		};
+		EAEB95CD26C66C83001A500D /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				EAEB95D026C66DC7001A500D /* URLSessionProtocol.swift */,
+			);
+			path = Protocols;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -274,6 +294,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EAEB95D126C66DC7001A500D /* URLSessionProtocol.swift in Sources */,
 				EAEB95CA26C65BAF001A500D /* ConnectionConfiguration.swift in Sources */,
 				C7927559262C562B00EF5D3A /* ViewController.swift in Sources */,
 				EAEB958726C56307001A500D /* StreamInformation.swift in Sources */,
@@ -290,6 +311,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EAEB95D726C68379001A500D /* DummyData.swift in Sources */,
+				EAEB95D526C67010001A500D /* MockStreamTask.swift in Sources */,
+				EAEB95D326C66F57001A500D /* MockURLSession.swift in Sources */,
 				EAEB95C226C64A1F001A500D /* StreamChatTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/StreamChat/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat/StreamChat.xcodeproj/project.pbxproj
@@ -13,6 +13,10 @@
 		C792755C262C562B00EF5D3A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C792755A262C562B00EF5D3A /* Main.storyboard */; };
 		C792755E262C562E00EF5D3A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C792755D262C562E00EF5D3A /* Assets.xcassets */; };
 		C7927561262C562E00EF5D3A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C792755F262C562E00EF5D3A /* LaunchScreen.storyboard */; };
+		EAEB958026C559C4001A500D /* ChatRoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEB957F26C559C4001A500D /* ChatRoom.swift */; };
+		EAEB958726C56307001A500D /* StreamInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEB958626C56307001A500D /* StreamInformation.swift */; };
+		EAEB958926C580F0001A500D /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEB958826C580F0001A500D /* Message.swift */; };
+		EAEB958B26C58138001A500D /* MessageSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEB958A26C58138001A500D /* MessageSender.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -24,6 +28,10 @@
 		C792755D262C562E00EF5D3A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C7927560262C562E00EF5D3A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C7927562262C562E00EF5D3A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		EAEB957F26C559C4001A500D /* ChatRoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoom.swift; sourceTree = "<group>"; };
+		EAEB958626C56307001A500D /* StreamInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamInformation.swift; sourceTree = "<group>"; };
+		EAEB958826C580F0001A500D /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
+		EAEB958A26C58138001A500D /* MessageSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageSender.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -56,15 +64,43 @@
 		C7927553262C562B00EF5D3A /* StreamChat */ = {
 			isa = PBXGroup;
 			children = (
+				EAEB958326C55C4B001A500D /* Model */,
+				EAEB958226C55C3F001A500D /* View */,
+				EAEB958126C55C31001A500D /* Controllers */,
 				C7927554262C562B00EF5D3A /* AppDelegate.swift */,
 				C7927556262C562B00EF5D3A /* SceneDelegate.swift */,
-				C7927558262C562B00EF5D3A /* ViewController.swift */,
 				C792755A262C562B00EF5D3A /* Main.storyboard */,
 				C792755D262C562E00EF5D3A /* Assets.xcassets */,
 				C792755F262C562E00EF5D3A /* LaunchScreen.storyboard */,
 				C7927562262C562E00EF5D3A /* Info.plist */,
 			);
 			path = StreamChat;
+			sourceTree = "<group>";
+		};
+		EAEB958126C55C31001A500D /* Controllers */ = {
+			isa = PBXGroup;
+			children = (
+				C7927558262C562B00EF5D3A /* ViewController.swift */,
+			);
+			path = Controllers;
+			sourceTree = "<group>";
+		};
+		EAEB958226C55C3F001A500D /* View */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		EAEB958326C55C4B001A500D /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				EAEB957F26C559C4001A500D /* ChatRoom.swift */,
+				EAEB958626C56307001A500D /* StreamInformation.swift */,
+				EAEB958826C580F0001A500D /* Message.swift */,
+				EAEB958A26C58138001A500D /* MessageSender.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -77,6 +113,7 @@
 				C792754D262C562B00EF5D3A /* Sources */,
 				C792754E262C562B00EF5D3A /* Frameworks */,
 				C792754F262C562B00EF5D3A /* Resources */,
+				EAEB952826C12FB0001A500D /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -132,13 +169,37 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		EAEB952826C12FB0001A500D /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nif which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		C792754D262C562B00EF5D3A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				C7927559262C562B00EF5D3A /* ViewController.swift in Sources */,
+				EAEB958726C56307001A500D /* StreamInformation.swift in Sources */,
 				C7927555262C562B00EF5D3A /* AppDelegate.swift in Sources */,
+				EAEB958B26C58138001A500D /* MessageSender.swift in Sources */,
+				EAEB958926C580F0001A500D /* Message.swift in Sources */,
+				EAEB958026C559C4001A500D /* ChatRoom.swift in Sources */,
 				C7927557262C562B00EF5D3A /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/StreamChat/StreamChat/Base.lproj/Main.storyboard
+++ b/StreamChat/StreamChat/Base.lproj/Main.storyboard
@@ -1,24 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="StreamChat" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="nHi-VT-tL4">
+                                <rect key="frame" x="159" y="176" width="97" height="34"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="135" y="138"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/StreamChat/StreamChat/Controllers/ViewController.swift
+++ b/StreamChat/StreamChat/Controllers/ViewController.swift
@@ -7,10 +7,10 @@
 import UIKit
 
 class ViewController: UIViewController {
-    let chatRoom = ChatRoom()
+    let chatRoom = ChatRoom(chatNetworkManager: ChatNetworkManager())
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        chatRoom.setUpNetwork()
         chatRoom.joinChat(username: "James")
     }
 }

--- a/StreamChat/StreamChat/Controllers/ViewController.swift
+++ b/StreamChat/StreamChat/Controllers/ViewController.swift
@@ -10,5 +10,7 @@ class ViewController: UIViewController {
     let chatRoom = ChatRoom()
     override func viewDidLoad() {
         super.viewDidLoad()
+        chatRoom.setUpNetwork()
+        chatRoom.joinChat(username: "James")
     }
 }

--- a/StreamChat/StreamChat/Controllers/ViewController.swift
+++ b/StreamChat/StreamChat/Controllers/ViewController.swift
@@ -7,12 +7,8 @@
 import UIKit
 
 class ViewController: UIViewController {
-
+    let chatRoom = ChatRoom()
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
     }
-
-
 }
-

--- a/StreamChat/StreamChat/Model/ChatNetworkManager.swift
+++ b/StreamChat/StreamChat/Model/ChatNetworkManager.swift
@@ -1,0 +1,64 @@
+//
+//  ChatNetworkManager.swift
+//  StreamChat
+//
+//  Created by James on 2021/08/17.
+//
+
+import Foundation
+
+final class ChatNetworkManager: NSObject, ChatNetworkManageable {
+    
+    var urlSession: URLSessionProtocol
+    var streamTask: URLSessionStreamTask?
+    
+    init(urlSession: URLSessionProtocol = URLSession.shared) {
+        self.urlSession = urlSession
+    }
+    
+    func setUpNetwork() {
+        let configuration = URLSessionConfiguration.default
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        urlSession = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+        self.streamTask = urlSession.streamTask(withHostName: StreamInformation.host, port: StreamInformation.portNumber)
+        streamTask?.resume()
+        read(from: streamTask)
+    }
+    
+    func read(from streamTask: URLSessionStreamTask?) {
+        streamTask?.readData(ofMinLength: ConnectionConfiguration.minimumReadLength, maxLength: ConnectionConfiguration.maximumReadLength, timeout: ConnectionConfiguration.timeOut) { [weak self] data, _, error in
+
+            defer {
+                self?.read(from: streamTask)
+            }
+            guard let data = data else {
+                return
+            }
+            
+            // MARK: - Read Log
+            NSLog(String(data: data, encoding: .utf8) ?? "no message could be read")
+            
+            if let readError = error {
+                NSLog(readError.localizedDescription)
+            }
+        }
+    }
+    
+    func write(data: Data) {
+        streamTask?.write(data, timeout: ConnectionConfiguration.timeOut) { error in
+            if let writeError = error {
+                NSLog(writeError.localizedDescription)
+            }
+        }
+    }
+    
+    func closeStream() {
+        urlSession.invalidateAndCancel()
+    }
+}
+extension ChatNetworkManager: URLSessionStreamDelegate {
+    func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
+        streamTask?.closeRead()
+        streamTask?.closeWrite()
+    }
+}

--- a/StreamChat/StreamChat/Model/ChatRoom.swift
+++ b/StreamChat/StreamChat/Model/ChatRoom.swift
@@ -1,0 +1,83 @@
+//
+//  ChatRoom.swift
+//  StreamChat
+//
+//  Created by James on 2021/08/12.
+//
+
+import UIKit
+
+final class ChatRoom: NSObject {
+    var urlSession: URLSession
+    var streamTask: URLSessionStreamTask?
+    var inputStream: InputStream?
+    var outputStream: OutputStream?
+    let maxReadLength = 2400
+    init(urlSession: URLSession = .shared) {
+        self.urlSession = urlSession
+        }
+    var username = ""
+    private func setUpNetwork() {
+        let configuration = URLSessionConfiguration.default
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        urlSession = URLSession(configuration: configuration, delegate: self, delegateQueue: .main)
+        streamTask = urlSession.streamTask(withHostName: StreamInformation.host, port: StreamInformation.portNumber)
+        streamTask?.startSecureConnection()
+        streamTask?.resume()
+        streamTask?.captureStreams()
+    }
+    func joinChat(username: String) {
+        guard let data = "USR_NAME::\(username)::END".data(using: .utf8) else {
+            return
+        }
+        data.withUnsafeBytes { unsafeRawBufferPointer in
+            guard let pointer = unsafeRawBufferPointer.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
+                return
+
+            }
+            outputStream?.write(pointer, maxLength: data.count)
+        }
+    }
+    private func readAvailableBytes(stream: InputStream) {
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: maxReadLength)
+        while stream.hasBytesAvailable {
+            let numberOfBytesRead = stream.read(buffer, maxLength: maxReadLength)
+            if numberOfBytesRead < 0 {
+                if let error = stream.streamError {
+                    NSLog(error.localizedDescription)
+                    break
+                }
+            }
+        }
+    }
+}
+extension ChatRoom: StreamDelegate {
+    func stream(_ aStream: Stream, handle eventCode: Stream.Event) {
+      switch eventCode {
+      case .hasBytesAvailable:
+        print("new message received")
+      case .endEncountered:
+        print("new message received")
+      case .errorOccurred:
+        print("error occurred")
+      case .hasSpaceAvailable:
+        print("has space available")
+      default:
+        print("some other event...")
+      }
+}
+}
+
+extension ChatRoom: URLSessionStreamDelegate {
+    func urlSession(_ session: URLSession, streamTask: URLSessionStreamTask, didBecome inputStream: InputStream, outputStream: OutputStream) {
+
+        self.inputStream = inputStream
+        self.inputStream?.delegate = self
+        self.outputStream = outputStream
+        self.outputStream?.delegate = self
+        self.inputStream?.schedule(in: .main, forMode: .default)
+        self.outputStream?.schedule(in: .main, forMode: .default)
+        self.inputStream?.open()
+        self.outputStream?.open()
+    }
+}

--- a/StreamChat/StreamChat/Model/ChatRoom.swift
+++ b/StreamChat/StreamChat/Model/ChatRoom.swift
@@ -58,10 +58,13 @@ final class ChatRoom: NSObject {
             defer {
                 self.read(from: streamTask)
             }
-            guard data != nil else {
-                
+            guard let data = data else {
                 return
             }
+            
+            // MARK: - Read Log
+            NSLog(String(data: data, encoding: .utf8) ?? "no message could be read")
+            
             if let readError = error {
                 NSLog(readError.localizedDescription)
             }

--- a/StreamChat/StreamChat/Model/ChatRoom.swift
+++ b/StreamChat/StreamChat/Model/ChatRoom.swift
@@ -10,14 +10,13 @@ import UIKit
 final class ChatRoom: NSObject {
     
     // MARK: - Properties
-    
-    var urlSession: URLSession
+    var urlSession: URLSessionProtocol
     var streamTask: URLSessionStreamTask?
     var username = ""
     
     // MARK: - Methods
     
-    init(urlSession: URLSession = .shared) {
+    init(urlSession: URLSessionProtocol = URLSession.shared) {
         self.urlSession = urlSession
     }
     

--- a/StreamChat/StreamChat/Model/ConnectionConfiguration.swift
+++ b/StreamChat/StreamChat/Model/ConnectionConfiguration.swift
@@ -1,0 +1,14 @@
+//
+//  ConnectionConfiguration.swift
+//  StreamChat
+//
+//  Created by 황인우 on 2021/08/13.
+//
+
+import Foundation
+
+struct ConnectionConfiguration {
+    static let minimumReadLength: Int = 1
+    static let maximumReadLength: Int = 2400
+    static let timeOut: Double = 0
+}

--- a/StreamChat/StreamChat/Model/Message.swift
+++ b/StreamChat/StreamChat/Model/Message.swift
@@ -1,0 +1,19 @@
+//
+//  Message.swift
+//  StreamChat
+//
+//  Created by James on 2021/08/13.
+//
+
+import Foundation
+
+struct Message {
+    let content: String
+    let senderUsername: String
+    let messageSender: MessageSender
+    init(content: String, senderUsername: String, messageSender: MessageSender) {
+        self.content = content
+        self.senderUsername = senderUsername
+        self.messageSender = messageSender
+    }
+}

--- a/StreamChat/StreamChat/Model/MessageSender.swift
+++ b/StreamChat/StreamChat/Model/MessageSender.swift
@@ -2,7 +2,7 @@
 //  MessageSender.swift
 //  StreamChat
 //
-//  Created by 황인우 on 2021/08/13.
+//  Created by James on 2021/08/13.
 //
 
 import Foundation

--- a/StreamChat/StreamChat/Model/MessageSender.swift
+++ b/StreamChat/StreamChat/Model/MessageSender.swift
@@ -1,0 +1,13 @@
+//
+//  MessageSender.swift
+//  StreamChat
+//
+//  Created by 황인우 on 2021/08/13.
+//
+
+import Foundation
+
+enum MessageSender {
+    case myself
+    case someoneElse
+}

--- a/StreamChat/StreamChat/Model/Protocols/ChatNetworkManageable.swift
+++ b/StreamChat/StreamChat/Model/Protocols/ChatNetworkManageable.swift
@@ -1,0 +1,15 @@
+//
+//  ChatNetworkManageable.swift
+//  StreamChat
+//
+//  Created by James on 2021/08/17.
+//
+
+import Foundation
+
+protocol ChatNetworkManageable: AnyObject {
+    func setUpNetwork()
+    func read(from streamTask: URLSessionStreamTask?)
+    func write(data: Data)
+    func closeStream()
+}

--- a/StreamChat/StreamChat/Model/Protocols/URLSessionProtocol.swift
+++ b/StreamChat/StreamChat/Model/Protocols/URLSessionProtocol.swift
@@ -1,0 +1,15 @@
+//
+//  URLSessionProtocol.swift
+//  StreamChat
+//
+//  Created by James on 2021/08/13.
+//
+
+import Foundation
+
+protocol URLSessionProtocol {
+    init(configuration: URLSessionConfiguration, delegate: URLSessionDelegate?, delegateQueue queue: OperationQueue?)
+    func streamTask(withHostName hostname: String, port: Int) -> URLSessionStreamTask
+    func invalidateAndCancel()
+}
+extension URLSession: URLSessionProtocol { }

--- a/StreamChat/StreamChat/Model/StreamError.swift
+++ b/StreamChat/StreamChat/Model/StreamError.swift
@@ -1,0 +1,13 @@
+//
+//  StreamError.swift
+//  StreamChat
+//
+//  Created by 황인우 on 2021/08/13.
+//
+
+import Foundation
+
+enum StreamError: Error {
+    case connectionError
+    case unknownError
+}

--- a/StreamChat/StreamChat/Model/StreamInformation.swift
+++ b/StreamChat/StreamChat/Model/StreamInformation.swift
@@ -1,0 +1,13 @@
+//
+//  StreamInformation.swift
+//  StreamChat
+//
+//  Created by 황인우 on 2021/08/12.
+//
+
+import Foundation
+
+struct StreamInformation {
+    static let host = "15.165.55.224"
+    static let portNumber = 5080
+}

--- a/StreamChat/StreamChat/Model/StreamInformation.swift
+++ b/StreamChat/StreamChat/Model/StreamInformation.swift
@@ -2,7 +2,7 @@
 //  StreamInformation.swift
 //  StreamChat
 //
-//  Created by 황인우 on 2021/08/12.
+//  Created by James on 2021/08/12.
 //
 
 import Foundation

--- a/StreamChat/StreamChatTests/DummyData.swift
+++ b/StreamChat/StreamChatTests/DummyData.swift
@@ -1,0 +1,12 @@
+//
+//  DummyData.swift
+//  StreamChatTests
+//
+//  Created by James on 2021/08/13.
+//
+
+import Foundation
+
+struct DummyData {
+    static let object = Data()
+}

--- a/StreamChat/StreamChatTests/Info.plist
+++ b/StreamChat/StreamChatTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/StreamChat/StreamChatTests/MockStreamTask.swift
+++ b/StreamChat/StreamChatTests/MockStreamTask.swift
@@ -1,0 +1,44 @@
+//
+//  MockStreamTask.swift
+//  StreamChatTests
+//
+//  Created by James on 2021/08/13.
+//
+@testable import StreamChat
+import Foundation
+
+final class MockStreamTask: URLSessionStreamTask {
+    var dataList = [Data]()
+    var timeLimit: TimeInterval = 10
+    var writeCounter: Int = 0
+    var readDataCounter: Int = 0
+    var closeWriteCounter: Int = 0
+    var closeReadCounter: Int = 0
+    var resumeDidCalled: Bool = false
+    var resultHandler: (() -> Void)?
+    var successfulDataString = "AvailableData"
+    override func resume() {
+        resumeDidCalled = true
+    }
+    
+    override func readData(ofMinLength minBytes: Int, maxLength maxBytes: Int, timeout: TimeInterval, completionHandler: @escaping (Data?, Bool, Error?) -> Void) {
+        let completeData = successfulDataString.data(using: .utf8)!
+        readDataCounter += 1
+        resultHandler?()
+        return completionHandler(completeData, true, nil)
+    }
+    
+    override func write(_ data: Data, timeout: TimeInterval, completionHandler: @escaping (Error?) -> Void) {
+        dataList.append(data)
+        writeCounter += 1
+        resultHandler?()
+    }
+    
+    override func closeWrite() {
+        closeWriteCounter += 1
+    }
+    
+    override func closeRead() {
+        closeReadCounter += 1
+    }
+}

--- a/StreamChat/StreamChatTests/MockURLSession.swift
+++ b/StreamChat/StreamChatTests/MockURLSession.swift
@@ -1,0 +1,35 @@
+//
+//  MockURLSession.swift
+//  StreamChatTests
+//
+//  Created by James on 2021/08/13.
+//
+@testable import StreamChat
+import Foundation
+
+final class MockURLSession: URLSessionProtocol {
+    
+    var configuration: URLSessionConfiguration
+    var delegate: URLSessionDelegate?
+    var delegateQueue: OperationQueue?
+    var didStreamConnectionFail = false
+    var mockStreamTask: MockStreamTask?
+    
+    init(configuration: URLSessionConfiguration, delegate: URLSessionDelegate?, delegateQueue: OperationQueue?) {
+        self.configuration = configuration
+        self.delegate = delegate
+        self.delegateQueue = delegateQueue
+    }
+    
+    func invalidateAndCancel() {
+        mockStreamTask?.closeRead()
+        mockStreamTask?.closeWrite()
+    }
+    
+    func streamTask(withHostName hostname: String, port: Int) -> URLSessionStreamTask {
+        mockStreamTask = MockStreamTask()
+        return mockStreamTask!
+    }
+    
+    
+}

--- a/StreamChat/StreamChatTests/StreamChatTests.swift
+++ b/StreamChat/StreamChatTests/StreamChatTests.swift
@@ -1,0 +1,22 @@
+//
+//  StreamChatTests.swift
+//  StreamChatTests
+//
+//  Created by 황인우 on 2021/08/13.
+//
+@testable import StreamChat
+import XCTest
+
+class StreamChatTests: XCTestCase {
+    var sut_chatroom: ChatRoom!
+    override func setUpWithError() throws {
+    }
+
+    override func tearDownWithError() throws {
+    }
+    func test_join_chat() {
+        sut_chatroom = ChatRoom()
+        sut_chatroom.setUpNetwork()
+        sut_chatroom.joinChat(username: "James")
+    }
+}

--- a/StreamChat/StreamChatTests/StreamChatTests.swift
+++ b/StreamChat/StreamChatTests/StreamChatTests.swift
@@ -9,6 +9,7 @@ import XCTest
 
 class StreamChatTests: XCTestCase {
     var sut_chatroom: ChatRoom!
+    var mock_networkmanager: ChatNetworkManager!
     var mock_urlsession: URLSessionProtocol!
     var mock_streamtask: MockStreamTask!
     
@@ -18,7 +19,10 @@ class StreamChatTests: XCTestCase {
         let configuration = URLSessionConfiguration.default
         configuration.requestCachePolicy = .reloadIgnoringCacheData
         mock_urlsession = MockURLSession(configuration: configuration, delegate: nil, delegateQueue: nil)
-        sut_chatroom = ChatRoom(urlSession: mock_urlsession)
+        mock_networkmanager = ChatNetworkManager(urlSession: mock_urlsession)
+        mock_streamtask = MockStreamTask()
+        mock_networkmanager.streamTask = mock_streamtask
+        sut_chatroom = ChatRoom(chatNetworkManager: mock_networkmanager)
         
     }
 
@@ -31,7 +35,7 @@ class StreamChatTests: XCTestCase {
         // given
         let expectation = XCTestExpectation()
         let name = "James"
-        mock_streamtask = MockStreamTask()
+        
         
         // when
         mock_streamtask.resultHandler = {

--- a/StreamChat/StreamChatTests/StreamChatTests.swift
+++ b/StreamChat/StreamChatTests/StreamChatTests.swift
@@ -9,14 +9,46 @@ import XCTest
 
 class StreamChatTests: XCTestCase {
     var sut_chatroom: ChatRoom!
+    var mock_urlsession: URLSessionProtocol!
+    var mock_streamtask: MockStreamTask!
+    
     override func setUpWithError() throws {
+        
+        // given
+        let configuration = URLSessionConfiguration.default
+        configuration.requestCachePolicy = .reloadIgnoringCacheData
+        mock_urlsession = MockURLSession(configuration: configuration, delegate: nil, delegateQueue: nil)
+        sut_chatroom = ChatRoom(urlSession: mock_urlsession)
+        
     }
 
     override func tearDownWithError() throws {
+        mock_urlsession = nil
     }
-    func test_join_chat() {
-        sut_chatroom = ChatRoom()
-        sut_chatroom.setUpNetwork()
-        sut_chatroom.joinChat(username: "James")
+    
+    func test_sut_chatroom_에서_joinChat메서드_호출시_streamtask가_정상적으로_writeData를_할수있는지_체크() {
+        
+        // given
+        let expectation = XCTestExpectation()
+        let name = "James"
+        mock_streamtask = MockStreamTask()
+        
+        // when
+        mock_streamtask.resultHandler = {
+            let expectedString = String(data: self.mock_streamtask.dataList.first!, encoding: .utf8)!
+            
+            // then
+            // verify that mock streamtask was able to write data and add it to expected array
+            XCTAssertEqual(self.mock_streamtask.dataList.count, 1)
+            
+            // verify that the written data is an expected data
+            XCTAssertEqual(expectedString, "James123")
+            
+            // verify that write method was called only once
+            XCTAssertEqual(self.mock_streamtask.writeCounter, 1)
+            expectation.fulfill()
+        }
+        sut_chatroom.joinChat(username: name)
+        wait(for: [expectation], timeout: 3)
     }
 }


### PR DESCRIPTION
@Limwin94
린, 조금 늦었지만 PR 보내봅니다. 시간 되실 때 꼼꼼한 리뷰 부탁드려요:)

# 구현내용
---
## Stream 연결 구축
- URLSessionStreamTask를 활용하여 read & write 메서드 구현
``` swift
private func read(from streamTask: URLSessionStreamTask?) {
        streamTask?.readData(ofMinLength: ConnectionConfiguration.minimumReadLength, maxLength: ConnectionConfiguration.maximumReadLength, timeout: ConnectionConfiguration.timeOut) { [weak self] data, _, error in
            guard let self = self else {
                
                return
            }
            defer {
                self.read(from: streamTask)
            }
            guard let data = data else {
                return
            }
            
            // MARK: - Read Log
            NSLog(String(data: data, encoding: .utf8) ?? "no message could be read")
            
            if let readError = error {
                NSLog(readError.localizedDescription)
            }
        }
    }
``` 
``` swift
private func write(data: Data) {
        streamTask?.write(data, timeout: ConnectionConfiguration.timeOut) { error in
            if let writeError = error {
                NSLog(writeError.localizedDescription)
            }
        }
    }
```

- setUpNetwork 
streamTask를 resume한 뒤 필요한 데이터를 read하도록 구현
``` swift
func setUpNetwork() {
        let configuration = URLSessionConfiguration.default
        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
        urlSession = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
        self.streamTask = urlSession.streamTask(withHostName: StreamInformation.host, port: StreamInformation.portNumber)
        streamTask?.resume()
        read(from: streamTask)
    }
```

- joinChat 메서드 구현
메세지 전송 스트림 형식에 맞게 data를 구현한 뒤 write하는 방식으로 구현
``` swift
func joinChat(username: String) {
        guard let data = "USR_NAME::\(username)::END".data(using: .utf8) else {
            
            return
        }
        write(data: data)
    }
```
## 소켓디버거를 활용하여 `setUpNetwork()`와 `joinChat()` 메서드를 실행할 경우 데이터를 실제로 읽고 쓸 수 있는지 체크
<img width="1233" alt="Screen Shot 2021-08-14 at 6 09 16 PM" src="https://user-images.githubusercontent.com/69072471/129441356-b4abf76a-932a-447d-a78f-a2e2e677ceeb.png">


# 고민한 점
---
## read() 메서드의 defer 부분
``` swift
private func read(from streamTask: URLSessionStreamTask?) {
        streamTask?.readData(ofMinLength: ConnectionConfiguration.minimumReadLength, maxLength: ConnectionConfiguration.maximumReadLength, timeout: ConnectionConfiguration.timeOut) { [weak self] data, _, error in
            guard let self = self else {
                
                return
            }
            defer {
                self.read(from: streamTask)
            }
            guard let data = data else {
                return
            }
            
            // MARK: - Read Log
            NSLog(String(data: data, encoding: .utf8) ?? "no message could be read")
            
            if let readError = error {
                NSLog(readError.localizedDescription)
            }
        }
```
read() 메서드를 viewController에서 호출할 경우 당연하겠지만 한 번만 data를 읽어오기 때문에 디버거를 채팅창에 올라오는 글을 한 번만 읽어올 수 있더라구요. 그래서 다른 다른 캠퍼분의 조언을 받아서 defer에 동일한 `read()` 메서드를 호출하여 지속적인 데이터 리딩이 가능하도록 설정을 했는데요. inputStream과 outputStream 같은 경우 event를 관리 해 주는 `StreamDelegate` 를 활용하여 아래와 같이 이벤트별 read 처리를 해 줄 수 있는데 제가 사용한 URLSessionStreamTask방식은 stream event처리를 해 주는 delegate가 없더라구요.
``` swift
extension ChatRoom: StreamDelegate {
  func stream(_ aStream: Stream, handle eventCode: Stream.Event) {
    switch eventCode {
    case .hasBytesAvailable:
      print("new message received")
      readAvailableBytes(stream: aStream as! InputStream)
    case .endEncountered:
      print("new message received")
      stopChatSession()
    case .errorOccurred:
      print("error occurred")
    case .hasSpaceAvailable:
      print("has space available")
    default:
      print("some other event...")
    }
  }
```
음...CFStream과 NSStream 모두 제가 잘 이해하기 힘든 방법이라서 URLSessionStreamTask 방식을 활용했는데요 이 방식을 유지해도 괜찮은지 궁금하고 만약 괜찮다면 `defer` 부분을 이대로 유지해도 되는지 아니면 더 나은 방법이 있는지 궁금합니다.

## MockURLStreamTask 객체 생성 실패와 test 실패
Chatroom의 메서드들을 네트워크와 분리된 테스트를 해 보고 싶어서 mock, stub, dummy 객체들을 만들어봤습니다. 그 중에 하나가 MockStreamTask인데요...
<img width="962" alt="Screen Shot 2021-08-14 at 7 44 50 PM" src="https://user-images.githubusercontent.com/69072471/129443844-bce457b4-73ff-4703-ac3f-33e902bb3289.png">

아래와 같이 `asynchronous was failed` 오류가 계속 뜨더라구요. 그래서 문제가 뭘까 디버깅을 해 보다가
아래와 같이 `mock_streamtask` 객체를 초기화 시켰음에도 값이 nil인 것을 확인 하였습니다.
<img width="962" alt="Screen Shot 2021-08-14 at 7 45 46 PM" src="https://user-images.githubusercontent.com/69072471/129443868-2ce75b27-2fe1-4fb0-a0f9-81848a636b20.png">
제 생각에는 mock_streamTask가 nil인 것 때문에 이 오류가 뜨는 것 같은데요...그런데 왜 초기화를 시켰는데도 nil값이 들어오는지 도통 모르겠습니다.... 린 생각에도 이 부분 때문에 오류가 뜨는것 같으신지요...만약 그렇다고 이 오류는 왜 나는걸까요?(MockStreamTask는 제가 보기에 정상적인 클래스인 것 같습니다...)

# 피드백 받고 싶은 부분
---
아키텍쳐에 대한 고민이 많은데요 요즘..음 현재 고민은 `ChatRoom`를 유지할지 아니면 `urlSession`그리고 `streamTask`를 관리하는 매니저 모델을 하나 생성해서 나누는게 좋을지 고민입니다. 제가 생각하는 전자의 장점은 chatRoom의 소켓통신을 자기 자신이 총괄하여 관리하기 때문에 별도의 delegate와 같은 통신 수단 없이 하나의 클래스 내에서 네트워크 작업을 처리할 수 있어서 코드와 파일양을 줄일 수 있다는 것입니다. 단점이라면...음 SOLID 단일 책임 원칙을 조금 위배한다는 생각이 들었습니다. ChatRoom이 joinChat 뿐 아니라 streamtask를 통해서 write하는 작업도 같이 하니까요.. 린은 어떻게 생각하시는지 궁금합니다.

긴 글 읽어 주셔서 감사합니다~ 답변 주시면 곰곰히 생각 해 보고 피드백 반영하도록 하겠습니다 :)